### PR TITLE
Avoid stack overflows when using Random.filter

### DIFF
--- a/test/filterTest.elm
+++ b/test/filterTest.elm
@@ -1,0 +1,35 @@
+module FilterTest exposing (..)
+
+import Html exposing (Html)
+import Random.Pcg as Random
+
+
+{-| This test checks that very difficult-to-satisfy filters do not result in a stack
+overflow (just run slowly). The test will take several seconds to run!
+-}
+main : Html Never
+main =
+    let
+        -- Try 'predicate i = False' to verify that the test hangs instead of
+        -- crashing with a stack overflow (indicating that tail recursion has
+        -- been properly optimized into a loop, which in this case happens to
+        -- be infinite).
+        predicate i =
+            i % 1000000 == 0
+
+        divisibleNumberGenerator =
+            Random.filter predicate (Random.int Random.minInt Random.maxInt)
+
+        listGenerator =
+            Random.list 10 divisibleNumberGenerator
+
+        initialSeed =
+            Random.initialSeed 1234
+
+        generatedList =
+            fst (Random.step listGenerator initialSeed)
+    in
+        -- You can verify that everything is working by observing that the generated
+        -- sum is in fact divisible by the chosen divisor (e.g. for a divisor of
+        -- 1000000 the sum should always have six trailing zeros)
+        Html.text (toString (List.sum generatedList))


### PR DESCRIPTION
The 'retry' helper function is tail-recursive so gets compiled into a
loop. This can be verified with the added test; it will run (slowly)
even for very difficult-to-satisfy predicates, and for impossible
predicates will hang (in an infinite loop) instead of crashing with a
stack overflow.
