### PR TITLE
Ensure 'independentSeed' produces valid seeds

### DIFF
--- a/src/Random/Pcg.elm
+++ b/src/Random/Pcg.elm
@@ -757,7 +757,7 @@ independentSeed =
                 Finally step it once before use.
                 --}
                 incr =
-                    (b `Bitwise.xor` c) `Bitwise.and` 1
+                    (b `Bitwise.xor` c) `Bitwise.or` 1
             in
                 ( seed1, next <| Seed state incr )
 

--- a/test/independentSeedTest.elm
+++ b/test/independentSeedTest.elm
@@ -1,0 +1,40 @@
+module IndependentSeedTest exposing (..)
+
+import Html exposing (Html)
+import Random.Pcg as Random exposing (Generator)
+import Debug
+
+
+{-| This test ensures that the 'independentSeed' generator actually produces
+valid random seeds that can be stepped properly to produce distinct values. If
+there is an error in 'independentSeed', at some point a seed such as 'Seed 0
+0' will be produced which when stepped will yield itself, resulting in an
+infinite loop within 'filter' (since it will internally just keep generating
+the same value over and over again).
+-}
+main : Html Never
+main =
+    let
+        initialSeed =
+            Random.initialSeed 1234
+
+        seedListGenerator =
+            Random.list 1000 Random.independentSeed
+
+        randomSeeds =
+            fst (Random.step seedListGenerator initialSeed)
+
+        isDivisible i =
+            let
+                _ =
+                    Debug.log "i" i
+            in
+                i /= 0 && i % 10 == 0
+
+        divisibleNumberGenerator =
+            Random.filter isDivisible (Random.int Random.minInt Random.maxInt)
+
+        divisibleNumbers =
+            List.map (Random.step divisibleNumberGenerator >> fst) randomSeeds
+    in
+        Html.text (toString (List.sum divisibleNumbers))


### PR DESCRIPTION
I don't fully understand the internals of 'independentSeed', so you may want to look at this issue more closely, but it seems to me that changing `Bitwise.and` to `Bitwise.or` is consistent with comments in the code (and seems to fix the issue illustrated by the added test).
